### PR TITLE
chore(server): Add grouping for angular deps in dependabot.yml.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
     directories:
       - "/client"
       - "/CDK"
+    groups:
+      angular:
+        applies-to: version-updates
+        patterns:
+          - "@angular*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build
         run: npm run build
-  gardle:
+  gradle:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add grouping for angular deps in dependabot.yml as there are a lot of PR's being added when new versions are released.