### PR TITLE
chore(test): Add test_user_session cookie value to requests made with…

### DIFF
--- a/src/main/java/com/example/controllers/AnonymousOrderController.java
+++ b/src/main/java/com/example/controllers/AnonymousOrderController.java
@@ -50,7 +50,7 @@ public class AnonymousOrderController {
             orderService.addOrder(order);
             return HttpResponse.ok(order);
         } catch (OrderRequestConverterException orderRequestConverterException) {
-            log.error("Error adding AnonymousOrder uid: {}", uid);
+            log.error("Error adding AnonymousOrder uid: {}", uid, orderRequestConverterException);
             return HttpResponse.badRequest();
         }
     }

--- a/src/main/java/com/example/mocks/MockAuthConfig.java
+++ b/src/main/java/com/example/mocks/MockAuthConfig.java
@@ -1,0 +1,21 @@
+package com.example.mocks;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties("mock-auth-config")
+public class MockAuthConfig {
+    /**
+     * When sessionLessStateAuth is true, a new test session id will be generated for each session.
+     * The generated session id is then used as the name in the Authentication object used by the application.
+     * This allows us to isolate automated e2e tests to allow for more consist results
+     */
+    private boolean sessionLessStateAuth = false;
+
+    public boolean isSessionLessStateAuth() {
+        return sessionLessStateAuth;
+    }
+
+    public void setSessionLessStateAuth(boolean sessionLessStateAuth) {
+        this.sessionLessStateAuth = sessionLessStateAuth;
+    }
+}

--- a/src/main/java/com/example/mocks/MockAuthenticationFetcher.java
+++ b/src/main/java/com/example/mocks/MockAuthenticationFetcher.java
@@ -1,8 +1,9 @@
-package com.example.Mocks;
+package com.example.mocks;
 
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.cookie.Cookie;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.authentication.ServerAuthentication;
 import jakarta.inject.Singleton;
@@ -16,10 +17,20 @@ import java.util.Map;
 @Requires(env = "mock_auth")
 @Replaces(AuthenticationFetcher.class)
 public class MockAuthenticationFetcher implements AuthenticationFetcher<HttpRequest<?>> {
+    private final MockAuthConfig mockAuthConfig;
+    MockAuthenticationFetcher(MockAuthConfig mockAuthConfig) {
+        this.mockAuthConfig = mockAuthConfig;
+    }
+
     @Override
     public Publisher<Authentication> fetchAuthentication(HttpRequest<?> request) {
+
+        Cookie testUserIdCookie = request.getCookies().get("test_user_session");
+        if (testUserIdCookie == null || !mockAuthConfig.isSessionLessStateAuth()) {
+            testUserIdCookie = Cookie.of("test_user_session", "steven");
+        }
         Map<String, Object> attributes = Map.of("name", "The bot meek");
-        Authentication authentication = new ServerAuthentication("steven", null, attributes);
+        Authentication authentication = new ServerAuthentication(testUserIdCookie.getValue(), null, attributes);
         return Mono.just(authentication);
     }
 }

--- a/src/main/java/com/example/mocks/TestIdInterceptor.java
+++ b/src/main/java/com/example/mocks/TestIdInterceptor.java
@@ -1,0 +1,40 @@
+package com.example.mocks;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import java.util.UUID;
+
+
+@Filter("/**")
+@Requires(env = "mock_auth")
+@Requires(property = "mock-auth-config.stateless-session-auth", value = "true")
+public class TestIdInterceptor implements HttpServerFilter {
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        // If a user-Agent is not provided, then we will assume that it is a unit test and proceed without the test_user_session cookie
+        if (!request.getHeaders().contains("user-Agent")) {
+            return chain.proceed(request);
+        }
+        Cookie testUserIdCookie = request.getCookies().get("test_user_session");
+        boolean hasCookieBeenAdded = testUserIdCookie != null;
+        if (!hasCookieBeenAdded) {
+            testUserIdCookie = Cookie.of("test_user_session", UUID.randomUUID().toString());
+            request = request.mutate().cookie(testUserIdCookie);
+        }
+
+        final Cookie finalTestUserIdCookie = testUserIdCookie;
+        return Mono.from(chain.proceed(request)).map((MutableHttpResponse<?> resp) -> {
+            if(!hasCookieBeenAdded) {
+                resp.cookie(finalTestUserIdCookie);
+            }
+            return resp;
+        });
+    }
+}

--- a/src/main/resources/application-mock_auth.yml
+++ b/src/main/resources/application-mock_auth.yml
@@ -22,6 +22,9 @@ endpoints:
   beans:
     enabled: true
     sensitive: false
+  env:
+    enabled: true
+    sensitive: false
 jackson:
   deserialization:
     readDateTimestampsAsNanoseconds: false
@@ -29,3 +32,6 @@ jackson:
   serialization:
     WRITE_DATE_TIMESTAMP_AS_NANOSECONDS: false
   serialization-inclusion: always
+
+mockAuthConfig:
+  sessionLessStateAuth: ${stateless-session-auth:true}


### PR DESCRIPTION
When mock-auth-config.stateless-session-auth is true and the env is mock_auth, a new test session id will be generated for each session.
The generated session id is then used as the name in the Authentication object used by the application.
This allows us to isolate automated e2e tests to allow for more consist results.